### PR TITLE
Add option to use symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Options:
         -o,--output-dir=PATH    If provided, ROMs will be copied to an output directory
                                 Ex.: -o "C:\Users\John\Downloads\Emulators\SNES\ROMs\1G1R"
         --move                  If set, ROMs will be moved, instead of copied, to the output directory
-        --link                  If set, ROMs will be symlinked (soft linked) to the output directory
+        --symlink               If set, ROMs will be symlinked (soft linked) to the output directory
                                 Please note newer versions of Windows 10 require elevated privileges to create symlinks
         --group-by-first-letter If set, groups ROMs on the output directory in subfolders according to the first letter in their name
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Options:
         --move                  If set, ROMs will be moved, instead of copied, to the output directory
         --symlink               If set, ROMs will be symlinked (soft linked) to the output directory
                                 Please note newer versions of Windows 10 require elevated privileges to create symlinks
+        --relative              If set along with --symlink, will create relative symlinks instead of absolute
         --group-by-first-letter If set, groups ROMs on the output directory in subfolders according to the first letter in their name
 
 # File scanning:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Options:
         -o,--output-dir=PATH    If provided, ROMs will be copied to an output directory
                                 Ex.: -o "C:\Users\John\Downloads\Emulators\SNES\ROMs\1G1R"
         --move                  If set, ROMs will be moved, instead of copied, to the output directory
+        --link                  If set, ROMs will be symlinked (soft linked) to the output directory
+                                Please note newer versions of Windows 10 require elevated privileges to create symlinks
         --group-by-first-letter If set, groups ROMs on the output directory in subfolders according to the first letter in their name
 
 # File scanning:

--- a/generate.py
+++ b/generate.py
@@ -520,7 +520,7 @@ def main(argv: List[str]):
             'all-regions-with-lang',
             'debug',
             'move',
-            'link',
+            'symlink',
             'chunk-size=',
             'threads=',
             'header-file=',
@@ -569,7 +569,7 @@ def main(argv: List[str]):
     group_by_first_letter = False
     language_weight = 3
     move = False
-    link = False
+    symlink = False
     global THREADS
     global RULES
     global MAX_FILE_SIZE
@@ -649,7 +649,7 @@ def main(argv: List[str]):
                 except OSError:
                     sys.exit(help_msg('invalid output DIR: %s' % output_dir))
         move |= opt == '--move'
-        link |= opt == '--link'
+        symlink |= opt == '--symlink'
         if opt == '--chunk-size':
             CHUNK_SIZE = int(arg)
         if opt == '--threads':
@@ -914,7 +914,7 @@ def main(argv: List[str]):
                                 rom_input_path,
                                 rom_output_path,
                                 move,
-                                link)
+                                symlink)
                             copied_files.add(rom_input_path)
                     else:
                         log(
@@ -936,9 +936,9 @@ def main(argv: List[str]):
                 if full_path.is_file():
                     if curr_out_dir:
                         curr_out_dir.mkdir(parents=True, exist_ok=True)
-                        if link:
+                        if symlink:
                             curr_out_dir = curr_out_dir / file_name
-                        transfer_file(full_path, curr_out_dir, move, link)
+                        transfer_file(full_path, curr_out_dir, move, symlink)
                     else:
                         printed_items.append(file_name)
                     break
@@ -955,7 +955,7 @@ def main(argv: List[str]):
                                     rom_input_path,
                                     rom_output_dir,
                                     move,
-                                    link)
+                                    symlink)
                                 shutil.copystat(
                                     str(full_path),
                                     str(rom_output_dir))
@@ -1047,12 +1047,12 @@ def transfer_file(
         input_path: Path,
         output_path: Path,
         move: bool,
-        link: bool) -> None:
+        symlink: bool) -> None:
     try:
         if move:
             print('Moving [%s] to [%s]' % (input_path, output_path))
             shutil.move(str(input_path), str(output_path))
-        elif link:
+        elif symlink:
             print('Linking [%s] to [%s]' % (input_path, output_path))
             output_path.symlink_to(input_path.resolve())
         else:
@@ -1107,7 +1107,7 @@ def help_msg(s: Optional[Union[str, Exception]] = None) -> str:
         'If set, ROMs will be moved, instead of copied, '
         'to the output directory',
 
-        '\t--link\t\t\t'
+        '\t--symlink\t\t'
         'If set, ROMs will be symlinked (soft linked) '
         'to the output directory'
         '\n\t\t\t\t'

--- a/generate.py
+++ b/generate.py
@@ -936,6 +936,8 @@ def main(argv: List[str]):
                 if full_path.is_file():
                     if curr_out_dir:
                         curr_out_dir.mkdir(parents=True, exist_ok=True)
+                        if link:
+                            curr_out_dir = curr_out_dir / file_name
                         transfer_file(full_path, curr_out_dir, move, link)
                     else:
                         printed_items.append(file_name)


### PR DESCRIPTION
Added the option to use symlinks when generating sets instead of copying

Using symlinks is neat because you can then create one or multiple different sets without ever needing to make more than one copy of the original ROM

Did a quick test on Linux and Windows 10, and according to the python docs it looks like creating symlinks on Windows 10 requires either administrative privileges or Developer Mode enabled