### PR TITLE
Add support for Homebrew ROMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Options:
         --no-sample             Filter out sample ROMs
         --no-pirate             Filter out pirate ROMs
         --no-aftermarket        Filter out aftermarket ROMs
+        --no-homebrew           Filter out homebrew ROMs
         --no-promo              Filter out promotion ROMs
         --no-all                Apply all filters above (WILL STILL ALLOW UNLICENSED ROMs)
         --no-unlicensed         Filter out unlicensed ROMs

--- a/generate.py
+++ b/generate.py
@@ -89,6 +89,7 @@ ENHANCEMENT_CHIP_REGEX = re.compile(r'\(Enhancement\s*Chip\)', re.IGNORECASE)
 UNL_REGEX = re.compile(re.escape('(Unl)'), re.IGNORECASE)
 PIRATE_REGEX = re.compile(re.escape('(Pirate)'), re.IGNORECASE)
 AFTERMARKET_REGEX = re.compile(re.escape('(Aftermarket)'), re.IGNORECASE)
+HOMEBREW_REGEX = re.compile(re.escape('(Homebrew)'), re.IGNORECASE)
 PROMO_REGEX = re.compile(re.escape('(Promo)'), re.IGNORECASE)
 BETA_REGEX = re.compile(r'\(Beta(?:\s*([a-z0-9.]+))?\)', re.IGNORECASE)
 PROTO_REGEX = re.compile(r'\(Proto(?:\s*([a-z0-9.]+))?\)', re.IGNORECASE)
@@ -209,6 +210,7 @@ def parse_games(
         filter_enhancement_chip: bool,
         filter_pirate: bool,
         filter_aftermarket: bool,
+        filter_homebrew: bool,
         filter_promo: bool,
         filter_unlicensed: bool,
         filter_proto: bool,
@@ -231,6 +233,8 @@ def parse_games(
         if filter_pirate and PIRATE_REGEX.search(game.name):
             continue
         if filter_aftermarket and AFTERMARKET_REGEX.search(game.name):
+            continue
+        if filter_homebrew and HOMEBREW_REGEX.search(game.name):
             continue
         if filter_promo and PROMO_REGEX.search(game.name):
             continue
@@ -499,6 +503,7 @@ def main(argv: List[str]):
             'no-proto',
             'no-pirate',
             'no-aftermarket',
+            'no-homebrew',
             'no-promo',
             'no-all',
             'no-unlicensed',
@@ -546,6 +551,7 @@ def main(argv: List[str]):
     filter_unlicensed = False
     filter_pirate = False
     filter_aftermarket = False
+    filter_homebrew = False
     filter_promo = False
     filter_proto = False
     filter_beta = False
@@ -616,6 +622,7 @@ def main(argv: List[str]):
         filter_sample |= opt in ('--no-sample', '--no-all')
         filter_pirate |= opt in ('--no-pirate', '--no-all')
         filter_aftermarket |= opt in ('--no-aftermarket', '--no-all')
+        filter_homebrew |= opt in ('--no-homebrew', '--no-all')
         filter_promo |= opt in ('--no-promo', '--no-all')
         filter_unlicensed |= opt == '--no-unlicensed'
         all_regions |= opt == '--all-regions'
@@ -750,6 +757,7 @@ def main(argv: List[str]):
         filter_enhancement_chip,
         filter_pirate,
         filter_aftermarket,
+        filter_homebrew,
         filter_promo,
         filter_unlicensed,
         filter_proto,
@@ -774,6 +782,7 @@ def main(argv: List[str]):
             (filter_unlicensed, 'Unlicensed ROMs'),
             (filter_pirate, 'Pirate ROMs'),
             (filter_aftermarket, 'Aftermarket ROMs'),
+            (filter_homebrew, 'Homebrew ROMs'),
             (filter_promo, 'Promo ROMs'),
             (only_selected_lang, 'ROMs not matching selected languages'),
             (bool(exclude_str), 'Excluded ROMs by name'),
@@ -1200,6 +1209,9 @@ def help_msg(s: Optional[Union[str, Exception]] = None) -> str:
 
         '\t--no-aftermarket\t\t'
         'Filter out aftermarket ROMs',
+
+        '\t--no-homebrew\t\t'
+        'Filter out homebrew ROMs',
 
         '\t--no-promo\t\t'
         'Filter out promotion ROMs',


### PR DESCRIPTION
This PR adds support for Homebrew ROMs. It is similar in functionality to the way Pirate ROMS are handled. This was requested because some homebrew ROMs don't have `Aftermarket` in their names. This fixes a comment in #37.